### PR TITLE
Allow null boolexpr

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Henning Berge <henning@henning.tech> (https://maulbot.com/)",
   "license": "MIT",
   "dependencies": {
-    "@types/node": "^12.0.7",
+    "@types/node": "^12.0.7"
   },
   "devDependencies": {
     "tslint": "^5.17.0",

--- a/src/jassParser.ts
+++ b/src/jassParser.ts
@@ -103,7 +103,7 @@ export class JassParser {
         }
     }
 
-    private static FixType(type: string): string {
+    private static FixType(type: string, isReturn = false): string {
         switch (type) {
             case 'real':
             case 'integer':
@@ -115,7 +115,11 @@ export class JassParser {
             case 'code':
                 type = '() => void';
                 break;
-            // case "boolexpr":
+            case "boolexpr":
+                if (!isReturn){
+                    type = 'boolexpr | null';
+                }
+                break;
             // case "conditionfunc":
             // case "filterfunc":
             // type = "() => boolean";
@@ -261,7 +265,7 @@ export class JassParser {
                     )}`;
 
             }
-            JassParser.writeLine(writer, line + `): ${JassParser.FixType(native.ReturnType)};`);
+            JassParser.writeLine(writer, line + `): ${JassParser.FixType(native.ReturnType, true)};`);
         }
 
         JassParser.blankLine(writer);
@@ -290,7 +294,7 @@ export class JassParser {
                     ).reduce((a, b) => a + ', ' + b)}`;
 
             }
-            JassParser.writeLine(writer, line + `): ${JassParser.FixType(funct.ReturnType)};`);
+            JassParser.writeLine(writer, line + `): ${JassParser.FixType(funct.ReturnType, true)};`);
         }
 
         fs.writeFileSync(outputFile, writer.join('\n'));

--- a/src/jassParser.ts
+++ b/src/jassParser.ts
@@ -3,7 +3,7 @@
  * Converting to Typescript: Henning Berge (Promises)
  */
 
-import fs, { WriteStream } from 'fs';
+import * as fs from 'fs';
 
 export interface TypeDefinition {
     Name: string;
@@ -250,7 +250,7 @@ export class JassParser {
         JassParser.blankLine(writer);
 
         for (const type of library.Types) {
-            JassParser.writeLine(writer, `declare interface ${type.Name} extends ${type.Parent} { __${type.Name}: never; };`);
+            JassParser.writeLine(writer, `declare interface ${type.Name} extends ${type.Parent} { __${type.Name}: never; }`);
         }
         JassParser.blankLine(writer);
         for (const native of library.Natives) {
@@ -280,7 +280,8 @@ export class JassParser {
                 line += ' var';
             }
             line += ` ${global.Name}`;
-            JassParser.writeLine(writer, line + `: ${JassParser.FixType(global.Type)};`);
+            const arrayText = (global.IsArray ? "[]" : "");
+            JassParser.writeLine(writer, line + `: ${JassParser.FixType(global.Type)}${arrayText};`);
         }
         JassParser.blankLine(writer);
 


### PR DESCRIPTION
Allows null boolexprs for function paramaters and global variables.